### PR TITLE
Switch to Go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/*
+/cen-server

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,0 @@
-.PHONY: coepi
-
-GOBIN = $(shell pwd)/bin
-GO ?= latest
-
-cen:
-		go build -o bin/cen
-		@echo "Done building cen.  Run \"$(GOBIN)/cen\" to launch cen."

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CEN API Go Server
 
-This is the Go implementation of the CEN API for _Privacy-Preserving Distributed Contact Tracing_,
-to be used in CEN Apps following CEN protocols.
+This is the Go implementation of the CEN API for _Privacy-Preserving Distributed
+Contact Tracing_, to be used in CEN Apps following CEN protocols.
 
 This is the Go implementation of the [CEN API](https://docs.google.com/document/d/1f65V3PI214-uYfZLUZtm55kdVwoazIMqGJrxcYNI4eg/edit) for _Privacy-Preserving Distributed Contact Tracing_.
 
@@ -139,10 +139,12 @@ ok	github.com/Co-Epi/coepi-backend-go/backend	0.032s
 ```
 
 ## Build + Run
-```
-$ make cen
-go build -o bin/cen
-Done building cen.  Run "bin/cen" to launch CEN Server.
+
+Requires Go > 1.12 with module support
+
+```sh
+go build
+./cen-server
 ```
 
 ## Test

--- a/cen.go
+++ b/cen.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/Co-Epi/coepi-backend-go/backend"
-	"github.com/Co-Epi/coepi-backend-go/server"
+	"github.com/Co-Epi/cen-server/backend"
+	"github.com/Co-Epi/cen-server/server"
 )
 
 const (

--- a/cen_test.go
+++ b/cen_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Co-Epi/coepi-backend-go/backend"
-	"github.com/Co-Epi/coepi-backend-go/server"
+	"github.com/Co-Epi/cen-server/backend"
+	"github.com/Co-Epi/cen-server/server"
 )
 
 // DefaultTransport contains all HTTP client operation parameters

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/Co-Epi/cen-server
+
+go 1.14
+
+require (
+	github.com/go-sql-driver/mysql v1.5.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/Co-Epi/coepi-backend-go v0.0.0-20200407232246-b446b8caba8a h1:5hNyoAB6m+I9AKGOyMpx/pwJIIQH1XqAg88mj1MAmEY=
+github.com/Co-Epi/coepi-backend-go v0.0.0-20200407232246-b446b8caba8a/go.mod h1:Lj2TEnwA4nPEiuAYYzR9BXOq0tA+PRYd3KyhvrEnZBw=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/server/server.go
+++ b/server/server.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Co-Epi/coepi-backend-go/backend"
+	"github.com/Co-Epi/cen-server/backend"
 )
 
 const (


### PR DESCRIPTION
As of Go 1.12 this is the standard way to define deps and build.

Also fix imports.